### PR TITLE
smiles browser on macOS

### DIFF
--- a/contrib/bin/smiles_browser.sh
+++ b/contrib/bin/smiles_browser.sh
@@ -2,7 +2,8 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-html="$(mktemp /tmp/smiles_browser.XXXXXX.html)"
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/smiles_browser.XXXXXX")"
+html="${tmpdir}/smiles_browser.html"
 
 python3 "${SCRIPT_DIR}/smiles_browser.py" "$@" -o "${html}"
 
@@ -11,4 +12,8 @@ if [[ ! -s "${html}" ]] ; then
   exit 1
 fi
 
-xdg-open "${html}"
+if [[ "$(uname -s)" == "Darwin" ]] ; then
+  open "${html}"
+else
+  xdg-open "${html}"
+fi


### PR DESCRIPTION
  - create a unique temp directory with mktemp -d, then write smiles_browser.html inside it
  - use open on macOS and keep xdg-open elsewhere
