### PR TITLE
Mac OS build changes

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -147,7 +147,7 @@ cc_library(
 )
 new_local_repository(
     name = "homebrew_openmp",
-    path = "/opt/homebrew/Cellar/libomp/22.1.6",
+    path = "/opt/homebrew/opt/libomp",
     build_file_content = """
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_proto_library", "cc_library", "cc_test")
 cc_library(

--- a/src/Utilities/GFP_Tools/BUILD
+++ b/src/Utilities/GFP_Tools/BUILD
@@ -1070,6 +1070,7 @@ cc_binary(
     srcs = [
         "nndata2bdb.cc",
     ],
+    tags = ["berkeleydb"],
     deps = [
         ":nearneighbours_cc_proto",
         "//Foundational/cmdline_v2:cmdline_v2",


### PR DESCRIPTION
- for homebrew libomp - use symlink rather than specific version
- include berkeleydb tag for BUILD in GFP_Tools