### PR TITLE
Fix stale //build_deps label; the package is //build_defs

### DIFF
--- a/src/Obsolete/Descriptor_Similarity/BUILD
+++ b/src/Obsolete/Descriptor_Similarity/BUILD
@@ -1,7 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_proto_library", "cc_library", "cc_test")
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//build_deps:install.bzl", "local_install")
+load("//build_defs:install.bzl", "local_install")
 
 local_install(
     name = "install",

--- a/src/go/BUILD
+++ b/src/go/BUILD
@@ -1,6 +1,6 @@
 load("@gazelle//:def.bzl", "gazelle")
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
-load("//build_deps:install.bzl", "local_install")
+load("//build_defs:install.bzl", "local_install")
 
 gazelle(name = "gazelle")
 


### PR DESCRIPTION
`src/Obsolete/Descriptor_Similarity/BUILD` and `src/go/BUILD` load `//build_deps:install.bzl`, but the package is `src/build_defs`. These are the only two loads of `install.bzl` in the tree and both carry the stale name.

The effect is worse than a skipped target. `install.sh` discovers what to install with a workspace-wide query:

    kind(cc_binary, //...:all) union kind(go_binary, //...:all)

Answering that requires loading every package, so one unparseable BUILD file makes the query fail and return nothing. `install.sh` then prints "0 files copied" and exits 0, and a container build succeeds with an empty `bin/Linux`. Note the existing `except (//Obsolete:all union //Duplicates:all)` does not help, since exclusion filters results after loading.

With the label fixed, install copies 331 executables.