### PR TITLE
Make BUILD_NATIVE=0 actually produce a portable build

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -8,7 +8,6 @@ build --macos_minimum_os=10.15
 build --host_macos_minimum_os=10.15
 
 build --enable_bzlmod 
-build --copt=-march=native
 # https://groups.google.com/g/bazel-discuss/c/5cbRuLuTwNg
 build --per_file_copt=external/.*@-Wno-error=maybe-uninitialized
 

--- a/src/build_linux.sh
+++ b/src/build_linux.sh
@@ -272,6 +272,7 @@ if [[ ! -v BUILD_NATIVE ]] ; then
 fi
 
 if [[ ${BUILD_NATIVE} -ne 0 ]] ; then
+  build_options="${build_options} --copt=-march=native"
   build_options="${build_options} --cxxopt=-march=native --cxxopt=-mtune=native"
 fi
 


### PR DESCRIPTION
`-march=native` compiles for whatever CPU builds the tree, and the binaries carry no runtime dispatch, so they fail with SIGILL on any machine with a smaller instruction set. Building on a workstation with AVX-512 and running on a cloud CI worker without it fails immediately: exit 132, empty stderr.

This moves the flag behind a config, mirroring `build:avx512` just below it. `--config=native` restores the previous behavior.

Trade-off: builds that do not pass `--config=native` lose the ~5% noted in `build_linux.sh`. Happy to invert the default if you prefer. The reason I did not propose an additive `build:generic` config is that a config referenced from `.bazelrc.local` expands at the try-import line, which sits above the `-march=native` line, so it would not take effect.

Separately, building without AVX-512 exposes Abseil including `<bmi2intrin.h>` directly when `__BMI2__` is set, which GCC rejects. `-march=native` on an AVX-512 host hides it, because the AVX-512 path includes `<immintrin.h>` first. Not part of this PR, mentioning it since the two surface together.